### PR TITLE
Corrected second typo in key parameters definition

### DIFF
--- a/zabbix_redis/template/zabbix_template_db_redis_custom.xml
+++ b/zabbix_redis/template/zabbix_template_db_redis_custom.xml
@@ -169,7 +169,7 @@ Once the limit is reached Redis will close all the new connections sending an er
                         </step>
                     </preprocessing>
                     <master_item>
-                        <key>redis.config[&quot;{$REDIS.HOST}&quot;, &quot;{$REDIS&gt;AUTH}&quot;]</key>
+                        <key>redis.config[&quot;{$REDIS.HOST}&quot;, &quot;{$REDIS.AUTH}&quot;]</key>
                     </master_item>
                 </item>
                 <item>


### PR DESCRIPTION
found a second typo in line 172. Fixed it, and tested it with importing to zabbix version 4.4.6